### PR TITLE
Editor enriquecido para secciones

### DIFF
--- a/src/components/Article/utilFunctions.tsx
+++ b/src/components/Article/utilFunctions.tsx
@@ -4,6 +4,30 @@ import { ArticleType } from "./types";
 export const contentParser = (content: string, article: ArticleType, isNumbered = false) => {
     const parsedContainer: JSX.Element[] = [];
     const paragraphClass = isNumbered ? "articleContainer--leftMargin" : "";
+    if (/<[a-z][\s\S]*>/i.test(content || "")) {
+        const regex = /\{([^}]+)\}/g;
+        let lastIndex = 0;
+        let match: RegExpExecArray | null;
+        while ((match = regex.exec(content)) !== null) {
+            const before = content.slice(lastIndex, match.index);
+            if (before && before.trim() !== "") {
+                parsedContainer.push(<div className={paragraphClass} dangerouslySetInnerHTML={{ __html: before }} />);
+            }
+            const imageId = match[1];
+            const src = article.imports.find((importedThing) => importedThing.id === imageId);
+            if (src) {
+                parsedContainer.push(<EmbedArticle related={src} />);
+            } else {
+                parsedContainer.push(<span className={paragraphClass} dangerouslySetInnerHTML={{ __html: `{${imageId}}` }} />);
+            }
+            lastIndex = regex.lastIndex;
+        }
+        const after = content.slice(lastIndex);
+        if (after && after.trim() !== "") {
+            parsedContainer.push(<div className={paragraphClass} dangerouslySetInnerHTML={{ __html: after }} />);
+        }
+        return parsedContainer;
+    }
 
     const normalized = (content || "").replace(/\r\n?/g, "\n");
 

--- a/src/components/RichTextEditor/richTextEditor.tsx
+++ b/src/components/RichTextEditor/richTextEditor.tsx
@@ -1,0 +1,38 @@
+import { useRef } from "react";
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const RichTextEditor = ({ value, onChange }: Props) => {
+  const editorRef = useRef<HTMLDivElement>(null);
+
+  const format = (cmd: string) => {
+    document.execCommand(cmd);
+    if (editorRef.current) onChange(editorRef.current.innerHTML);
+  };
+
+  const handleInput = () => {
+    if (editorRef.current) onChange(editorRef.current.innerHTML);
+  };
+
+  return (
+    <div>
+      <div>
+        <button type="button" onClick={() => format("bold")}>B</button>
+        <button type="button" onClick={() => format("italic")}>I</button>
+        <button type="button" onClick={() => format("underline")}>U</button>
+      </div>
+      <div
+        ref={editorRef}
+        contentEditable
+        onInput={handleInput}
+        dangerouslySetInnerHTML={{ __html: value }}
+        style={{ border: "1px solid #ccc", minHeight: "100px", padding: "8px" }}
+      />
+    </div>
+  );
+};
+
+export default RichTextEditor;

--- a/src/pages/ArticleEditor/components/sectionTab/sectionTab.tsx
+++ b/src/pages/ArticleEditor/components/sectionTab/sectionTab.tsx
@@ -4,6 +4,7 @@ import { FormDataArticle } from "pages/ArticleEditor/articleEditorFunctions";
 import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import "./sectionTab.scss";
+import RichTextEditor from "components/RichTextEditor/richTextEditor";
 
 interface SectionsTabProps {
   formData: FormDataArticle;
@@ -76,9 +77,9 @@ const SectionForm = ({
       </div>
       <div className="formTab__formElement sectionsTab__editable--long" >
         <label htmlFor="content">Contenido</label>
-        <textarea
+        <RichTextEditor
           value={section.content}
-          onChange={(e) => updateField("content", e.target.value)}
+          onChange={(val) => updateField("content", val)}
         />
       </div>
       <div className="formTab__formElement formTab__formElement--inline">


### PR DESCRIPTION
## Resumen
- Añade componente `RichTextEditor` basado en `contentEditable` con barra de formato básica.
- Sustituye el `textarea` en el editor de secciones por `RichTextEditor` para almacenar HTML.
- Actualiza `contentParser` para interpretar y renderizar contenido HTML.

## Testing
- `npm test` *(falla: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a44bf709f88322aa58b119d40e1db9