### PR TITLE
feat: parse article markdown with react-markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "vite-tsconfig-paths": "^5.1.4",
     "sharp": "^0.33.3",
     "fast-glob": "^3.3.2",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "react-markdown": "^9.0.0"
   },
   "scripts": {
     "start": "vite",

--- a/src/components/Article/components/sections.tsx
+++ b/src/components/Article/components/sections.tsx
@@ -16,7 +16,7 @@ const Sections = (props: SectionProps) => {
         <>
             {
                 sections.map((sectionObject) => {
-                    let finalSection = [];
+                    let finalSection: JSX.Element[] = [];
                     if (sectionObject.isNumbered) {
                         articlesQuantity += 1;
                         finalSection.push(<h2 id={sectionObject.title} className={props.className ? `${props.className}` : 'articleContainer__title'}>{parentTitle}{articlesQuantity} {sectionObject.title}</h2>);
@@ -28,7 +28,7 @@ const Sections = (props: SectionProps) => {
                     if (sectionObject.subtitle != null)
                         finalSection.push(<p className="articleContainer__subtitle articleContainer--leftMargin">{sectionObject.subtitle}</p>);
 
-                    finalSection = finalSection.concat(contentParser(sectionObject.content, article, props.isChild != null));
+                    finalSection.push(contentParser(sectionObject.content, article, props.isChild != null));
 
                     if (sectionObject.subSections != null && sectionObject.subSections.length > 0) {
                         finalSection.push(<Sections article={article} sections={sectionObject.subSections} parentTitle={articlesQuantity + '.'} className="articleContainer__title2 articleContainer--leftMargin" isChild={true} />);;


### PR DESCRIPTION
## Summary
- parse article content with `react-markdown` and replace `{id}` tokens with embedded components
- adjust section rendering to use new parser
- add `react-markdown` dependency

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-markdown)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a44bf70c548322a02b05f81b56d7ae