### PR TITLE
Add markdown toolbar with shortcuts

### DIFF
--- a/src/components/MarkdownEditor/markdownEditor.scss
+++ b/src/components/MarkdownEditor/markdownEditor.scss
@@ -1,0 +1,25 @@
+.markdownEditor {
+  display: flex;
+  flex-direction: column;
+}
+.markdownEditor__toolbar {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.markdownEditor__toolbar button,
+.markdownEditor__toolbar a {
+  background: none;
+  border: 1px solid #ccc;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.markdownEditor__help {
+  text-decoration: none;
+}
+.markdownEditor textarea {
+  min-height: 150px;
+}

--- a/src/components/MarkdownEditor/markdownEditor.tsx
+++ b/src/components/MarkdownEditor/markdownEditor.tsx
@@ -1,0 +1,92 @@
+import { useRef } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faBold, faItalic, faLink, faCode, faListUl, faListOl, faQuestion } from "@fortawesome/free-solid-svg-icons";
+import "./markdownEditor.scss";
+
+interface MarkdownEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const MarkdownEditor = ({ value, onChange }: MarkdownEditorProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const applyFormatting = (prefix: string, suffix = prefix) => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const selected = textarea.value.slice(start, end);
+    const before = textarea.value.slice(0, start);
+    const after = textarea.value.slice(end);
+    const newText = before + prefix + selected + suffix + after;
+    onChange(newText);
+    setTimeout(() => {
+      textarea.focus();
+      textarea.selectionStart = start + prefix.length;
+      textarea.selectionEnd = end + prefix.length;
+    });
+  };
+
+  const applyList = (ordered: boolean) => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const text = textarea.value;
+    const selected = text.slice(start, end);
+    const lines = selected.split("\n");
+    const formatted = lines
+      .map((line, i) => (ordered ? `${i + 1}. ${line}` : `- ${line}`))
+      .join("\n");
+    const before = text.slice(0, start);
+    const after = text.slice(end);
+    const newText = before + formatted + after;
+    onChange(newText);
+    setTimeout(() => {
+      textarea.focus();
+      textarea.selectionStart = start;
+      textarea.selectionEnd = start + formatted.length;
+    });
+  };
+
+  const insertLink = () => {
+    const url = window.prompt("URL") || "";
+    applyFormatting("[", `](${url})`);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.ctrlKey || e.metaKey) {
+      if (e.key === "b") {
+        e.preventDefault();
+        applyFormatting("**");
+      }
+      if (e.key === "i") {
+        e.preventDefault();
+        applyFormatting("*");
+      }
+      if (e.key === "k") {
+        e.preventDefault();
+        insertLink();
+      }
+    }
+  };
+
+  return (
+    <div className="markdownEditor">
+      <div className="markdownEditor__toolbar">
+        <button type="button" onClick={() => applyFormatting("**")}> <FontAwesomeIcon icon={faBold} /> </button>
+        <button type="button" onClick={() => applyFormatting("*")}> <FontAwesomeIcon icon={faItalic} /> </button>
+        <button type="button" onClick={insertLink}> <FontAwesomeIcon icon={faLink} /> </button>
+        <button type="button" onClick={() => applyFormatting("`")}> <FontAwesomeIcon icon={faCode} /> </button>
+        <button type="button" onClick={() => applyList(false)}> <FontAwesomeIcon icon={faListUl} /> </button>
+        <button type="button" onClick={() => applyList(true)}> <FontAwesomeIcon icon={faListOl} /> </button>
+        <a href="https://commonmark.org/help" target="_blank" rel="noreferrer" className="markdownEditor__help"> <FontAwesomeIcon icon={faQuestion} /> </a>
+      </div>
+      <textarea ref={textareaRef} value={value} onChange={(e) => onChange(e.target.value)} onKeyDown={handleKeyDown} />
+    </div>
+  );
+};
+
+export default MarkdownEditor;
+

--- a/src/components/MarkdownEditor/markdownEditor.tsx
+++ b/src/components/MarkdownEditor/markdownEditor.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faBold, faItalic, faLink, faCode, faListUl, faListOl, faQuestion } from "@fortawesome/free-solid-svg-icons";
+import { faBold, faItalic, faLink, faListUl, faListOl, faQuestion, faQuoteRight, faHeading } from "@fortawesome/free-solid-svg-icons";
 import "./markdownEditor.scss";
 
 interface MarkdownEditorProps {
@@ -19,12 +19,16 @@ const MarkdownEditor = ({ value, onChange }: MarkdownEditorProps) => {
     const selected = textarea.value.slice(start, end);
     const before = textarea.value.slice(0, start);
     const after = textarea.value.slice(end);
-    const newText = before + prefix + selected + suffix + after;
+    const has = before.endsWith(prefix) && after.startsWith(suffix);
+    const newText = has
+      ? before.slice(0, before.length - prefix.length) + selected + after.slice(suffix.length)
+      : before + prefix + selected + suffix + after;
+    const offset = has ? -prefix.length : prefix.length;
     onChange(newText);
     setTimeout(() => {
       textarea.focus();
-      textarea.selectionStart = start + prefix.length;
-      textarea.selectionEnd = end + prefix.length;
+      textarea.selectionStart = start + offset;
+      textarea.selectionEnd = end + offset;
     });
   };
 
@@ -36,8 +40,60 @@ const MarkdownEditor = ({ value, onChange }: MarkdownEditorProps) => {
     const text = textarea.value;
     const selected = text.slice(start, end);
     const lines = selected.split("\n");
+    const is = ordered
+      ? lines.every((line) => /^\d+\. /.test(line))
+      : lines.every((line) => /^- /.test(line));
     const formatted = lines
-      .map((line, i) => (ordered ? `${i + 1}. ${line}` : `- ${line}`))
+      .map((line, i) => {
+        if (ordered) return is ? line.replace(/^\d+\. /, "") : `${i + 1}. ${line}`;
+        return is ? line.replace(/^- /, "") : `- ${line}`;
+      })
+      .join("\n");
+    const before = text.slice(0, start);
+    const after = text.slice(end);
+    const newText = before + formatted + after;
+    onChange(newText);
+    setTimeout(() => {
+      textarea.focus();
+      textarea.selectionStart = start;
+      textarea.selectionEnd = start + formatted.length;
+    });
+  };
+
+  const toggleHeading = () => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const text = textarea.value;
+    const selected = text.slice(start, end);
+    const lines = selected.split("\n");
+    const is = lines.every((line) => /^# /.test(line));
+    const formatted = lines
+      .map((line) => (is ? line.replace(/^# /, "") : `# ${line}`))
+      .join("\n");
+    const before = text.slice(0, start);
+    const after = text.slice(end);
+    const newText = before + formatted + after;
+    onChange(newText);
+    setTimeout(() => {
+      textarea.focus();
+      textarea.selectionStart = start;
+      textarea.selectionEnd = start + formatted.length;
+    });
+  };
+
+  const toggleQuote = () => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const text = textarea.value;
+    const selected = text.slice(start, end);
+    const lines = selected.split("\n");
+    const is = lines.every((line) => /^> /.test(line));
+    const formatted = lines
+      .map((line) => (is ? line.replace(/^> /, "") : `> ${line}`))
       .join("\n");
     const before = text.slice(0, start);
     const after = text.slice(end);
@@ -51,6 +107,24 @@ const MarkdownEditor = ({ value, onChange }: MarkdownEditorProps) => {
   };
 
   const insertLink = () => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const selected = textarea.value.slice(start, end);
+    const linkMatch = selected.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
+    if (linkMatch) {
+      const before = textarea.value.slice(0, start);
+      const after = textarea.value.slice(end);
+      const newText = before + linkMatch[1] + after;
+      onChange(newText);
+      setTimeout(() => {
+        textarea.focus();
+        textarea.selectionStart = start;
+        textarea.selectionEnd = start + linkMatch[1].length;
+      });
+      return;
+    }
     const url = window.prompt("URL") || "";
     applyFormatting("[", `](${url})`);
   };
@@ -75,13 +149,14 @@ const MarkdownEditor = ({ value, onChange }: MarkdownEditorProps) => {
   return (
     <div className="markdownEditor">
       <div className="markdownEditor__toolbar">
-        <button type="button" onClick={() => applyFormatting("**")}> <FontAwesomeIcon icon={faBold} /> </button>
-        <button type="button" onClick={() => applyFormatting("*")}> <FontAwesomeIcon icon={faItalic} /> </button>
-        <button type="button" onClick={insertLink}> <FontAwesomeIcon icon={faLink} /> </button>
-        <button type="button" onClick={() => applyFormatting("`")}> <FontAwesomeIcon icon={faCode} /> </button>
-        <button type="button" onClick={() => applyList(false)}> <FontAwesomeIcon icon={faListUl} /> </button>
-        <button type="button" onClick={() => applyList(true)}> <FontAwesomeIcon icon={faListOl} /> </button>
-        <a href="https://commonmark.org/help" target="_blank" rel="noreferrer" className="markdownEditor__help"> <FontAwesomeIcon icon={faQuestion} /> </a>
+        <button type="button" title="Negrita" onClick={() => applyFormatting("**")}> <FontAwesomeIcon icon={faBold} /> </button>
+        <button type="button" title="Cursiva" onClick={() => applyFormatting("*")}> <FontAwesomeIcon icon={faItalic} /> </button>
+        <button type="button" title="Enlace" onClick={insertLink}> <FontAwesomeIcon icon={faLink} /> </button>
+        <button type="button" title="Lista" onClick={() => applyList(false)}> <FontAwesomeIcon icon={faListUl} /> </button>
+        <button type="button" title="Lista numerada" onClick={() => applyList(true)}> <FontAwesomeIcon icon={faListOl} /> </button>
+        <button type="button" title="Encabezado" onClick={toggleHeading}> <FontAwesomeIcon icon={faHeading} /> </button>
+        <button type="button" title="Cita" onClick={toggleQuote}> <FontAwesomeIcon icon={faQuoteRight} /> </button>
+        <a href="https://commonmark.org/help" target="_blank" rel="noreferrer" className="markdownEditor__help" title="Ayuda"> <FontAwesomeIcon icon={faQuestion} /> </a>
       </div>
       <textarea ref={textareaRef} value={value} onChange={(e) => onChange(e.target.value)} onKeyDown={handleKeyDown} />
     </div>

--- a/src/pages/ArticleEditor/components/sectionTab/sectionTab.tsx
+++ b/src/pages/ArticleEditor/components/sectionTab/sectionTab.tsx
@@ -3,6 +3,7 @@ import { Section } from "components/Article/types";
 import { FormDataArticle } from "pages/ArticleEditor/articleEditorFunctions";
 import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import MarkdownEditor from "components/MarkdownEditor/markdownEditor";
 import "./sectionTab.scss";
 
 interface SectionsTabProps {
@@ -76,10 +77,7 @@ const SectionForm = ({
       </div>
       <div className="formTab__formElement sectionsTab__editable--long" >
         <label htmlFor="content">Contenido</label>
-        <textarea
-          value={section.content}
-          onChange={(e) => updateField("content", e.target.value)}
-        />
+        <MarkdownEditor value={section.content} onChange={(v) => updateField("content", v)} />
       </div>
       <div className="formTab__formElement formTab__formElement--inline">
         <input


### PR DESCRIPTION
## Summary
- add reusable Markdown editor with toolbar, formatting buttons and help link
- support keyboard shortcuts for bold, italic and links
- integrate Markdown editor into article section form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a47548b8988322be927f9cf5a2ec13